### PR TITLE
if in no orgs return empty array

### DIFF
--- a/controllers/user/user.go
+++ b/controllers/user/user.go
@@ -187,6 +187,9 @@ func (c *Controller) GetUserOrganizationsById(ctx context.Context, userId string
 		}
 	}
 
+	if len(orgIds) == 0 {
+		return &[]organization.Organization{}, nil
+	}
 	query, args, err := sqlx.In(`SELECT * FROM Organizations WHERE id IN (?)`, orgIds)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Problem
See #35 for details
Closes #35 

# Solution
A check is now made after looping through all of a user's roles if no organization is found we return an empty array:
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/4fa2eb5f-ec8a-4806-9b70-910df80b0cb2)
