### PR TITLE
Get all boards in an org

### DIFF
--- a/controllers/organization/organization.go
+++ b/controllers/organization/organization.go
@@ -212,3 +212,20 @@ func (c *Controller) RemoveMember(userId string, organizationId string) error {
 	}
 	return nil
 }
+
+func (c *Controller) GetBoardsInOrg(ctx context.Context, orgId string) (*[]string, error) {
+	boardIds := []string{}
+
+	allBoards, err := c.db.DB.Query("SELECT id FROM Boards WHERE organization_id = $1", orgId)
+	if err != nil {
+		return nil, err
+	}
+	for allBoards.Next() {
+		var boardId string
+		if err := allBoards.Scan(&boardId); err != nil {
+			return &boardIds, err
+		}
+		boardIds = append(boardIds, boardId)
+	}
+	return &boardIds, nil
+}

--- a/controllers/organization/organization.go
+++ b/controllers/organization/organization.go
@@ -229,3 +229,13 @@ func (c *Controller) GetBoardsInOrg(ctx context.Context, orgId string) (*[]strin
 	}
 	return &boardIds, nil
 }
+
+func (c *Controller) CheckBoardPrivacy(ctx context.Context, boardId string) (bool, error) {
+	privacy := true
+	err := c.db.DB.GetContext(ctx, &privacy, `SELECT is_private FROM Boards WHERE id=$1;
+	`, boardId)
+	if err != nil {
+		return true, err
+	}
+	return privacy, nil
+}

--- a/routers/organizationRouter.go
+++ b/routers/organizationRouter.go
@@ -319,7 +319,7 @@ func (handler *organizationHandler) GetAllBoards(writer http.ResponseWriter, req
 	}
 
 	ctx := request.Context()
-	boardsInOrg, err := handler.controller.GetBoardsInOrg(ctx, organizationId)
+	visibleBoards, err := handler.controller.GetViewableBoardsInOrg(ctx, organizationId, userId)
 	if err != nil {
 		if err.Error() == sql.ErrNoRows.Error() {
 			http.Error(writer, fmt.Sprintf("No organization found with id %s", organizationId), http.StatusNotFound)
@@ -328,23 +328,8 @@ func (handler *organizationHandler) GetAllBoards(writer http.ResponseWriter, req
 		}
 		return
 	}
-	returnedBoards := []string{}
-	for _, element := range *boardsInOrg {
-		// TODO: CHECK IF THE BOARD IS PRIVATE
-		isBoardPrivate, err := handler.controller.CheckBoardPrivacy(ctx, element)
-		readPrivateBoardPerm := fmt.Sprintf("org%s:board%s:read", organizationId, element)
-		canReadPrivateBoard, err := auth.HasPermission(userId, readPrivateBoardPerm)
-		if !((!canReadPrivateBoard) && (isBoardPrivate)) {
-			returnedBoards = append(returnedBoards, element)
-		}
-		if err != nil {
-			http.Error(writer, fmt.Sprintf("Failed to get user permissions: %s", err.Error()), http.StatusInternalServerError)
-			return
-		}
-	}
-	// fmt.Println(returnedBoards)
 
 	writer.Header().Set("Content-Type", "application/json")
 	writer.WriteHeader(http.StatusOK)
-	json.NewEncoder(writer).Encode(returnedBoards)
+	json.NewEncoder(writer).Encode(visibleBoards)
 }

--- a/routers/organizationRouter.go
+++ b/routers/organizationRouter.go
@@ -31,6 +31,7 @@ func registerOrganizationRoutes(parentRouter *mux.Router, cfg *config.Config, db
 	handler.router.Handle(fmt.Sprintf("%s/{organizationId}", organizationsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.GetOrganization))).Methods("GET")
 	handler.router.Handle(fmt.Sprintf("%s/{organizationId}", organizationsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.UpdateOrganization))).Methods("PUT")
 	handler.router.Handle(fmt.Sprintf("%s/{organizationId}", organizationsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.DeleteOrganization))).Methods("DELETE")
+	handler.router.Handle(fmt.Sprintf("%s/{organizationId}/boards", organizationsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.GetAllBoards))).Methods("GET")
 	handler.router.Handle(fmt.Sprintf("%s/{organizationId}/members", organizationsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.GetOrganizationMembers))).Methods("GET")
 	handler.router.Handle(fmt.Sprintf("%s/{organizationId}/members", organizationsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.AddMemberToOrganization))).Methods("POST")
 	handler.router.Handle(fmt.Sprintf("%s/{organizationId}/members/{memberId}", organizationsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.RemoveMemberFromOrganization))).Methods("DELETE")
@@ -295,4 +296,39 @@ func (handler *organizationHandler) RemoveMemberFromOrganization(writer http.Res
 	}
 	writer.Header().Set("Content-Type", "application/json")
 	writer.WriteHeader(http.StatusNoContent)
+}
+
+func (handler *organizationHandler) GetAllBoards(writer http.ResponseWriter, request *http.Request) {
+	params := mux.Vars(request)
+	organizationId := params["organizationId"]
+	if organizationId == "" {
+		http.Error(writer, "No Organization ID Found", http.StatusBadRequest)
+		return
+	}
+	token := request.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
+	userId := token.RegisteredClaims.Subject
+	readOrgPerm := fmt.Sprintf("org%s:read", organizationId)
+	canReadOrg, err := auth.HasPermission(userId, readOrgPerm)
+	if err != nil {
+		http.Error(writer, fmt.Sprintf("Failed to get user permissions: %s", err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if !canReadOrg {
+		http.Error(writer, fmt.Sprintf("User does not have permission to read organization with id: %s", organizationId), http.StatusForbidden)
+		return
+	}
+
+	ctx := request.Context()
+	boardsInOrg, err := handler.controller.GetBoardsInOrg(ctx, organizationId)
+	if err != nil {
+		if err.Error() == sql.ErrNoRows.Error() {
+			http.Error(writer, fmt.Sprintf("No organization found with id %s", organizationId), http.StatusNotFound)
+		} else {
+			http.Error(writer, fmt.Sprintf("Failed to get organization: %s", err.Error()), http.StatusInternalServerError)
+		}
+		return
+	}
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusOK)
+	json.NewEncoder(writer).Encode(boardsInOrg)
 }


### PR DESCRIPTION
Closes #51 

## Successful call 

Database state for context
![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/06512ca2-db1e-4244-8763-869f434f6cfe)
![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/71aedae1-b828-420d-bda4-624bfc03ab86)

On an org that you do not have permissions in 
![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/ff869bb0-aa4f-406e-9011-5f12e7a2bae9)


## Hiding private boards
Bottom three boards are the example:
![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/d5fc865d-b47c-426b-bf37-9dfeff5a41ce)
Bottom is private, but I am a member. Second is private, and I am not a member. Top is not private and I am not a member. Call should return the top and bottom test boards, ids ending in 4ca6 and d5d4. This is indeed the response. 
![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/d1344dec-f5ff-40e0-9d58-5acd1a56e627)

## Org with no boards
![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/1a7f2256-1d6f-4014-8a61-c6cd1a68d703)
Replies with empty array 
