### PR TITLE
Self Removal of Roles

### DIFF
--- a/routers/boardRouter.go
+++ b/routers/boardRouter.go
@@ -356,7 +356,7 @@ func (handler *boardHandler) RemoveMemberFromBoard(writer http.ResponseWriter, r
 	userId := token.RegisteredClaims.Subject
 	removeUsersPerm := fmt.Sprintf("org%s:board%s:remove_members", organizationId, boardId)
 	canRemoveUsers := tokenCustomClaims.HasPermission(removeUsersPerm)
-	if !canRemoveUsers {
+	if !canRemoveUsers && userId != memberId {
 		http.Error(writer, fmt.Sprintf("User with id %s does not have permission to add users to org %s board with id %s", userId, organizationId, boardId), http.StatusForbidden)
 		return
 	}

--- a/routers/organizationRouter.go
+++ b/routers/organizationRouter.go
@@ -260,7 +260,7 @@ func (handler *organizationHandler) RemoveMemberFromOrganization(writer http.Res
 	userId := token.RegisteredClaims.Subject
 	removeUsersPerm := fmt.Sprintf("org%s:remove_members", organizationId)
 	canRemoveUsers := tokenCustomClaims.HasPermission(removeUsersPerm)
-	if !canRemoveUsers {
+	if !canRemoveUsers && userId != memberId {
 		http.Error(writer, fmt.Sprintf("User with id %s does not have permission to remove users from organization with id: %s", userId, organizationId), http.StatusForbidden)
 		return
 	}

--- a/routers/roleRouter.go
+++ b/routers/roleRouter.go
@@ -493,7 +493,7 @@ func (handler *roleHandler) RemoveMemberFromRole(writer http.ResponseWriter, req
 	orgPrefix := fmt.Sprintf("org%s", organizationId)
 	readOrgPerm := fmt.Sprintf("%s:read", orgPrefix)
 	canReadOrg := tokenCustomClaims.HasPermission(readOrgPerm)
-	if !canReadOrg {
+	if !canReadOrg && userId != memberId {
 		http.Error(writer, fmt.Sprintf("User you're trying to remove role from (%s) does not have permission to read organization with id: %s", memberId, organizationId), http.StatusForbidden)
 		return
 	}


### PR DESCRIPTION
Closes #63 

A check is now made on the `RemoveMemberFromOrganization`, `RemoveMemberFromRole`, and `RemoveMemberFromBoard` functions seeing if who they are removing is themselves. While this is fine for now we probably need to go back and check exactly what's being removed. For example, if there is one owner and they remove themselves from that role this should not be allowed and now all roles could be lost to time. I can add this to this PR if wanted but wasn't sure if out of scope