### PR TITLE
Org Owner Board Control

### DIFF
--- a/auth/authorization.go
+++ b/auth/authorization.go
@@ -15,11 +15,29 @@ func (c CustomClaims) HasScope(expectedScope string) bool {
 }
 
 func (c CustomClaims) HasPermission(permissionName string) bool {
-	userPermissions := c.Permissions
-	for _, permission := range userPermissions {
+	for _, permission := range c.Permissions {
 		if permission == permissionName {
 			return true
 		}
 	}
 	return false
+}
+
+func (c CustomClaims) HasAnyPermissions(permissionNames ...string) bool {
+	for _, permissionName := range permissionNames {
+		if c.HasPermission(permissionName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c CustomClaims) HasAllPermissions(permissionNames ...string) bool {
+	foundPermissions := make([]string, 0)
+	for _, permissionName := range permissionNames {
+		if c.HasPermission(permissionName) {
+			foundPermissions = append(foundPermissions, permissionName)
+		}
+	}
+	return len(foundPermissions) == len(permissionNames)
 }

--- a/controllers/board/board.go
+++ b/controllers/board/board.go
@@ -24,10 +24,9 @@ func (c *Controller) GetViewableBoardsInOrg(ctx context.Context, tokenCustomClai
 	for _, board := range orgBoards {
 		if board.IsPrivate {
 			readBoardPerm := fmt.Sprintf("%s:board%s:read", orgPrefix, board.Id)
-			canReadBoard := tokenCustomClaims.HasPermission(readBoardPerm)
 			boardsAdminPerm := fmt.Sprintf("%s:boards_admin", orgPrefix)
-			isBoardsAdmin := tokenCustomClaims.HasPermission(boardsAdminPerm)
-			if !canReadBoard && !isBoardsAdmin {
+			canReadBoard := tokenCustomClaims.HasAnyPermissions(readBoardPerm, boardsAdminPerm)
+			if !canReadBoard {
 				continue
 			}
 		}

--- a/controllers/board/board.go
+++ b/controllers/board/board.go
@@ -19,12 +19,15 @@ func (c *Controller) GetViewableBoardsInOrg(ctx context.Context, tokenCustomClai
 		return nil, err
 	}
 
+	orgPrefix := fmt.Sprintf("org%s", orgId)
 	var viewableBoards []Board
 	for _, board := range orgBoards {
 		if board.IsPrivate {
-			readBoardPerm := fmt.Sprintf("org%s:board%s:read", orgId, board.Id)
+			readBoardPerm := fmt.Sprintf("%s:board%s:read", orgPrefix, board.Id)
 			canReadBoard := tokenCustomClaims.HasPermission(readBoardPerm)
-			if !canReadBoard {
+			boardsAdminPerm := fmt.Sprintf("%s:boards_admin", orgPrefix)
+			isBoardsAdmin := tokenCustomClaims.HasPermission(boardsAdminPerm)
+			if !canReadBoard && !isBoardsAdmin {
 				continue
 			}
 		}

--- a/controllers/organization/organization.go
+++ b/controllers/organization/organization.go
@@ -65,7 +65,7 @@ func (c *Controller) InitializeOrganization(ownerId string, organizationId strin
 		Name:        fmt.Sprintf("org%s:create_boards", organizationId),
 		Description: fmt.Sprintf("Allows you to create boards in the organization with id %s", organizationId),
 	}
-	boardAdminPerm := auth.Permission{
+	boardsAdminPerm := auth.Permission{
 		Name:        fmt.Sprintf("org%s:boards_admin", organizationId),
 		Description: fmt.Sprintf("Allows you to so anything in regards to any board in organizaiton with id %s", organizationId),
 	}
@@ -93,7 +93,7 @@ func (c *Controller) InitializeOrganization(ownerId string, organizationId strin
 	orgMemberPermissions := []auth.Permission{
 		readPerm, createBoardsPerm,
 	}
-	orgOwnerPermissions := append(orgMemberPermissions, deletePerm, updatePerm, addMembersPerm, removeMembersPerm, boardAdminPerm, createRolesPerm, editRolesPerm, deleteRolesPerm, addRolesPerm, removeRolesPerm)
+	orgOwnerPermissions := append(orgMemberPermissions, deletePerm, updatePerm, addMembersPerm, removeMembersPerm, boardsAdminPerm, createRolesPerm, editRolesPerm, deleteRolesPerm, addRolesPerm, removeRolesPerm)
 
 	// Because the owner role has all permissions, we only need to call CreatePermissions once
 	err = auth.CreatePermissions(orgOwnerPermissions)

--- a/controllers/organization/organization.go
+++ b/controllers/organization/organization.go
@@ -61,6 +61,14 @@ func (c *Controller) InitializeOrganization(ownerId string, organizationId strin
 		Name:        fmt.Sprintf("org%s:remove_members", organizationId),
 		Description: fmt.Sprintf("Allows you to remove members from the organization with id %s", organizationId),
 	}
+	createBoardsPerm := auth.Permission{
+		Name:        fmt.Sprintf("org%s:create_boards", organizationId),
+		Description: fmt.Sprintf("Allows you to create boards in the organization with id %s", organizationId),
+	}
+	boardAdminPerm := auth.Permission{
+		Name:        fmt.Sprintf("org%s:boards_admin", organizationId),
+		Description: fmt.Sprintf("Allows you to so anything in regards to any board in organizaiton with id %s", organizationId),
+	}
 	createRolesPerm := auth.Permission{
 		Name:        fmt.Sprintf("org%s:create_roles", organizationId),
 		Description: fmt.Sprintf("Allows you to use create roles for the organization with id %s", organizationId),
@@ -83,9 +91,9 @@ func (c *Controller) InitializeOrganization(ownerId string, organizationId strin
 	}
 
 	orgMemberPermissions := []auth.Permission{
-		readPerm,
+		readPerm, createBoardsPerm,
 	}
-	orgOwnerPermissions := append(orgMemberPermissions, deletePerm, updatePerm, addMembersPerm, removeMembersPerm, createRolesPerm, editRolesPerm, deleteRolesPerm, addRolesPerm, removeRolesPerm)
+	orgOwnerPermissions := append(orgMemberPermissions, deletePerm, updatePerm, addMembersPerm, removeMembersPerm, boardAdminPerm, createRolesPerm, editRolesPerm, deleteRolesPerm, addRolesPerm, removeRolesPerm)
 
 	// Because the owner role has all permissions, we only need to call CreatePermissions once
 	err = auth.CreatePermissions(orgOwnerPermissions)


### PR DESCRIPTION
# Problem
See #43 for details
Closes #43 

# Solution
When creating an organization the org owner will now be initialized with the `boardsAdminPerm`. This permission allows you can see and do anything to all boards (give out sparingly). A part of this PR is slight modifications and tweaks to methods. 2 new methods called `HasAnyPermissions` and `HasAllPermissions` have been created to streamline the code and try to make it a little more readable.

Also, there was no perm for creating boards so the `createBoardsPerm` was created and given to members by default to an organization.

Doing testing the refactors/new code changes works, they are all just the same routes so not gonna put the wall of sc here but being the pr is mainly sligh refactors should be good