### PR TITLE
BUG: Panel details not grabbing stacks

### DIFF
--- a/controllers/board/panel.go
+++ b/controllers/board/panel.go
@@ -152,6 +152,7 @@ func (c *Controller) GetCompletePanelById(ctx context.Context, panelId string) (
 			} else {
 				completeStack.Cards = make([]CompleteCard, 0)
 			}
+			completePanel.Stacks = append(completePanel.Stacks, completeStack)
 		}
 	} else {
 		completePanel.Stacks = make([]CompleteStack, 0)


### PR DESCRIPTION
# Problem
See #73 for details
Closes #73

# Solution
At the end of the for loop on get complete panel, it was never appending the stacks to the array. It now does!
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/531e10be-0024-4baf-b1f8-3075c48c1c92)
