### PR TITLE
Adding Story Points to Cards

### DIFF
--- a/controllers/board/board.go
+++ b/controllers/board/board.go
@@ -402,11 +402,8 @@ func (c *Controller) CreateBoardWithAI(ctx context.Context, userId string, name 
 			return nil, err
 		}
 		for _, task := range tasks {
-			// TODO: Update DB to use story points lol
-			// _, err := c.CreateCard(ctx, task.CardTitle, task.CardDesc, task.CardStoryPoints.(string), newStack.Id.String()
-			_, err := c.CreateCard(ctx, task.CardTitle, task.CardDesc, newStack.Id.String())
+			_, err := c.CreateCard(ctx, task.CardTitle, task.CardDesc, task.CardStoryPoints, newStack.Id.String())
 			if err != nil {
-				// handle the case where task.CardStoryPoints is not a string (or some other error occurred)
 				return nil, err
 			}
 		}

--- a/controllers/board/card.go
+++ b/controllers/board/card.go
@@ -21,7 +21,7 @@ func (c *Controller) GetCardsByStackId(ctx context.Context, stackId string) (*[]
 	return &cards, nil
 }
 
-func (c *Controller) CreateCard(ctx context.Context, title string, description string, stackId string) (*models.Card, error) {
+func (c *Controller) CreateCard(ctx context.Context, title string, description string, points string, stackId string) (*models.Card, error) {
 	var nextPosition int
 	err := c.db.DB.GetContext(ctx, &nextPosition, `
 		SELECT COALESCE(MAX(position)+1, 0) AS next_position FROM Cards where stack_id=$1;
@@ -31,8 +31,8 @@ func (c *Controller) CreateCard(ctx context.Context, title string, description s
 	}
 	cardId := uuid.New().String()
 	_, err = c.db.DB.ExecContext(ctx, `
-		INSERT INTO Cards (id, title, description, position, stack_id) VALUES ($1, $2, $3, $4, $5);
-	`, cardId, title, description, nextPosition, stackId)
+		INSERT INTO Cards (id, title, description, points, position, stack_id) VALUES ($1, $2, $3, $4, $5, $6);
+	`, cardId, title, description, points, nextPosition, stackId)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (c *Controller) GetCardById(ctx context.Context, cardId string) (*models.Ca
 	return &card, nil
 }
 
-func (c *Controller) UpdateCardById(ctx context.Context, boardId string, stackId string, cardId string, newStackId string, title string, description string, position *int) error {
+func (c *Controller) UpdateCardById(ctx context.Context, boardId string, stackId string, cardId string, newStackId string, title string, description string, points string, position *int) error {
 	card, err := c.GetCardById(ctx, cardId)
 	if err != nil {
 		return err
@@ -126,8 +126,8 @@ func (c *Controller) UpdateCardById(ctx context.Context, boardId string, stackId
 		}
 	}
 	_, err = c.db.DB.ExecContext(ctx, `
-		UPDATE Cards SET title=$1, description=$2, position=$3, stack_id=$4 WHERE id=$5;
-	`, title, description, *position, newStackId, cardId)
+		UPDATE Cards SET title=$1, description=$2, points=$3, position=$4, stack_id=$5 WHERE id=$6;
+	`, title, description, points, *position, newStackId, cardId)
 	if err != nil {
 		return err
 	}

--- a/models/board.go
+++ b/models/board.go
@@ -22,6 +22,7 @@ type Card struct {
 	Id          uuid.UUID `db:"id" json:"id"`
 	Title       string    `db:"title" json:"title"`
 	Description string    `db:"description" json:"description"`
+	Points      int       `db:"points" json:"points"`
 	Position    int       `db:"position" json:"position"`
 	StackId     uuid.UUID `db:"stack_id" json:"stack_id"`
 }
@@ -78,16 +79,17 @@ type CompleteCard struct {
 	Id          uuid.UUID `db:"id" json:"id"`
 	Title       string    `db:"title" json:"title"`
 	Description string    `db:"description" json:"description"`
+	Points      int       `db:"points" json:"points"`
 	Position    int       `db:"position" json:"position"`
 	StackId     uuid.UUID `db:"stack_id" json:"stack_id"`
 	Assignments []string  `json:"assignments"`
 }
 
 type AIGeneratedCard struct {
-	AssignedUsers   []string    `json:"assigned"`
-	CardTitle       string      `json:"title"`
-	CardDesc        string      `json:"description"`
-	CardStoryPoints interface{} `json:"story_points"`
+	AssignedUsers   []string `json:"assigned"`
+	CardTitle       string   `json:"title"`
+	CardDesc        string   `json:"description"`
+	CardStoryPoints string   `json:"story_points"`
 }
 
 type AIGeneratedSprint map[string][]AIGeneratedCard

--- a/routers/boardRouter.go
+++ b/routers/boardRouter.go
@@ -992,6 +992,7 @@ func (handler *boardHandler) CreateCard(writer http.ResponseWriter, request *htt
 		return
 	}
 	description := request.FormValue("description")
+	points := request.FormValue("points")
 
 	token := request.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
 	tokenCustomClaims := token.CustomClaims.(*auth.CustomClaims)
@@ -1011,7 +1012,7 @@ func (handler *boardHandler) CreateCard(writer http.ResponseWriter, request *htt
 		return
 	}
 
-	card, err := handler.controller.CreateCard(request.Context(), title, description, stackId)
+	card, err := handler.controller.CreateCard(request.Context(), title, description, points, stackId)
 	if err != nil {
 		http.Error(writer, fmt.Sprintf("Failed to create card: %s", err.Error()), http.StatusInternalServerError)
 		return
@@ -1083,6 +1084,7 @@ func (handler *boardHandler) UpdateCard(writer http.ResponseWriter, request *htt
 
 	title := request.FormValue("title")
 	description := request.FormValue("description")
+	points := request.FormValue("points")
 	var position *int
 	if request.FormValue("position") != "" {
 		var err error
@@ -1108,7 +1110,7 @@ func (handler *boardHandler) UpdateCard(writer http.ResponseWriter, request *htt
 	}
 
 	ctx := request.Context()
-	err := handler.controller.UpdateCardById(ctx, boardId, stackId, cardId, newStackId, title, description, position)
+	err := handler.controller.UpdateCardById(ctx, boardId, stackId, cardId, newStackId, title, description, points, position)
 	if err != nil {
 		http.Error(writer, fmt.Sprintf("Failed to update card with id %s: %s", cardId, err.Error()), http.StatusInternalServerError)
 		return

--- a/sql/SQL-CreateFillerData.sql
+++ b/sql/SQL-CreateFillerData.sql
@@ -51,10 +51,10 @@ INSERT INTO Stacks(id, title, position, panel_id) VALUES
     ('fe031a7e-7529-48a2-b674-0447b8e5844f', 'Lorem Ipsum 2: Electric Boogaloo', 2, '69639276-a0bb-4a9c-b0b8-9b66b7aaaf31'),
     ('f4d08871-f86b-4716-bc91-1807ab5efabd', 'Lorem Ipsum 3: Return of the Ipsum', 3, '69639276-a0bb-4a9c-b0b8-9b66b7aaaf31');
 
-INSERT INTO Cards(id, title, description, position, stack_id) VALUES
-    ('f2785b0b-333a-4cfa-abbc-a668246cebcf', 'Testing Card', 'A filler card created for demo', 1, '865be2f9-2025-4a4a-a62f-96509092bea2'),
-    ('6f45243d-dd8b-4494-ae6e-96a50cc3dcbf', 'Testing Card', 'A filler card created for demo', 2, '865be2f9-2025-4a4a-a62f-96509092bea2'),
-    ('4ae5b20d-289f-4a76-9777-2ec727be8379', 'Testing Card', 'A filler card created for demo', 3, '865be2f9-2025-4a4a-a62f-96509092bea2'),
-    ('78c0bc19-cd2c-48df-9a6c-6a6f6f1479c4', 'Testing Card', 'A filler card created for demo', 4, '865be2f9-2025-4a4a-a62f-96509092bea2'),
-    ('61969f1a-0c32-4c6a-9372-1c87c7f9c196', 'Testing Card', 'A filler card created for demo', 5, '865be2f9-2025-4a4a-a62f-96509092bea2'),
-    ('b73e47ba-61ed-4ee6-8806-c95b0d48e7e2', 'Testing Card', 'A filler card created for demo', 6, '865be2f9-2025-4a4a-a62f-96509092bea2');
+INSERT INTO Cards(id, title, description, points, position, stack_id) VALUES
+    ('f2785b0b-333a-4cfa-abbc-a668246cebcf', 'Testing Card', 'A filler card created for demo', 'XL', 1, '865be2f9-2025-4a4a-a62f-96509092bea2'),
+    ('6f45243d-dd8b-4494-ae6e-96a50cc3dcbf', 'Testing Card', 'A filler card created for demo', 'XS', 2, '865be2f9-2025-4a4a-a62f-96509092bea2'),
+    ('4ae5b20d-289f-4a76-9777-2ec727be8379', 'Testing Card', 'A filler card created for demo', 'L', 3, '865be2f9-2025-4a4a-a62f-96509092bea2'),
+    ('78c0bc19-cd2c-48df-9a6c-6a6f6f1479c4', 'Testing Card', 'A filler card created for demo', 'M', 4, '865be2f9-2025-4a4a-a62f-96509092bea2'),
+    ('61969f1a-0c32-4c6a-9372-1c87c7f9c196', 'Testing Card', 'A filler card created for demo', 'M', 5, '865be2f9-2025-4a4a-a62f-96509092bea2'),
+    ('b73e47ba-61ed-4ee6-8806-c95b0d48e7e2', 'Testing Card', 'A filler card created for demo', 'S', 6, '865be2f9-2025-4a4a-a62f-96509092bea2');

--- a/sql/SQL-Setup.sql
+++ b/sql/SQL-Setup.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS Cards (
     id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
     title           VARCHAR(255) NOT NULL,
     description     TEXT,
+    points          VARCHAR(30) NOT NULL DEFAULT 0;
     position        SMALLINT,
     stack_id        UUID, FOREIGN KEY (stack_id) REFERENCES Stacks(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
# Problem
See #75 for details
Closes #75

# Solution
The `points` column has been added to the `Cards` table and all card models/functions have been updated to now have this value

## Screenshots
Detailed/Regular get Cards:
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/51b5ea4a-bb64-4288-b220-47a0a21ad152)

Create Card:
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/cee60f06-d892-4144-b125-5f559748202c)

Update Card:
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/04c9839b-e653-450d-91d5-b960740586f2)
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/c08a8804-2fdc-47da-a64e-68376638ef16)

Didn't test board creation but can if wanted. Being it used these functions I assume it works fine. Have office hours so want to get down b4 <3