### PR TITLE
AI Card Creation

### DIFF
--- a/controllers/board/card.go
+++ b/controllers/board/card.go
@@ -1,9 +1,13 @@
 package board
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"net/http"
 
 	"github.com/Sync-Space-49/syncspace-server/models"
@@ -172,6 +176,61 @@ func (c *Controller) DeleteCardById(ctx context.Context, boardId string, stackId
 	return nil
 }
 
+func (c *Controller) CreateCardWithAI(ctx context.Context, boardId string, cardStackId string) (*models.Card, error) {
+	requestUrl := fmt.Sprintf("http://%s/api/generate/board", c.cfg.AI.APIHost)
+
+	detailedBoard, err := c.GetCompleteBoardById(ctx, boardId)
+	if err != nil {
+		return nil, err
+	}
+	formattedBoard := models.CopyToSimplifiedCompleteBoard(*detailedBoard)
+
+	type AICardPayload struct {
+		StackId string                         `json:"stack_id"`
+		Board   models.SimplifiedCompleteBoard `json:"board"`
+	}
+	aiCardPayload := AICardPayload{
+		StackId: cardStackId,
+		Board:   formattedBoard,
+	}
+
+	var payload bytes.Buffer
+	err = json.NewEncoder(&payload).Encode(aiCardPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	method := "POST"
+	req, err := http.NewRequest(method, requestUrl, &payload)
+	if err != nil {
+		fmt.Printf("error making http request: %s\n", err)
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Fatalf("Error occurred during conversion of HTTP resonse body into bytes. %v", err)
+		return nil, err
+	}
+
+	var aiCard models.AIGeneratedCard
+	err = json.Unmarshal(body, &aiCard)
+	if err != nil {
+		return nil, err
+	}
+	CardStoryPointsString := fmt.Sprintf("%v", aiCard.CardStoryPoints)
+	card, err := c.CreateCard(ctx, aiCard.CardTitle, aiCard.CardDesc, CardStoryPointsString, boardId, cardStackId)
+	if err != nil {
+		return nil, err
+	}
+	return card, nil
+}
+
 func (c *Controller) AssignCardToUser(ctx context.Context, boardId string, cardId string, userId string) error {
 	_, err := c.db.DB.ExecContext(ctx, `
 		INSERT INTO assigned_cards (user_id, card_id) VALUES ($1, $2);
@@ -266,39 +325,4 @@ func (c *Controller) GetCompleteCardById(ctx context.Context, cardId string) (*m
 	}
 
 	return &completeCard, nil
-}
-
-func (c *Controller) CreateCardWithAI(ctx context.Context, panelId string) (*models.Card, error) {
-
-	requestUrl := fmt.Sprintf("%s/ai/generate/card", c.cfg.AI.APIHost)
-	res, err := http.Get(requestUrl)
-	if err != nil {
-		fmt.Printf("error making http request: %s\n", err)
-	}
-	// json.Marshal(res)
-	// This prints the AI generated card JSON
-	fmt.Print(res)
-
-	// cardId := uuid.New().String()
-	// // title, description, panelId,
-	// // stackId = "AI Generated Cards"
-
-	// _, err := c.db.DB.ExecContext(ctx, `
-	// 	INSERT INTO Cards (id, title, description, stack_id) VALUES ($1, $2, $3, $4);
-	// `, cardId, title, description, panelId)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// card, err := c.GetCardById(ctx, cardId)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// return card, nil
-
-	// err = c.UpdateBoardModifiedAt(ctx, boardId)
-	// if err != nil {
-	// 	return err
-	// }
-
-	return nil, nil
 }

--- a/controllers/board/card.go
+++ b/controllers/board/card.go
@@ -177,7 +177,7 @@ func (c *Controller) DeleteCardById(ctx context.Context, boardId string, stackId
 }
 
 func (c *Controller) CreateCardWithAI(ctx context.Context, boardId string, cardStackId string) (*models.Card, error) {
-	requestUrl := fmt.Sprintf("http://%s/api/generate/board", c.cfg.AI.APIHost)
+	requestUrl := fmt.Sprintf("http://%s/api/generate/card", c.cfg.AI.APIHost)
 
 	detailedBoard, err := c.GetCompleteBoardById(ctx, boardId)
 	if err != nil {

--- a/models/board.go
+++ b/models/board.go
@@ -43,6 +43,7 @@ type Board struct {
 	Id             uuid.UUID `db:"id" json:"id"`
 	OwnerId        string    `db:"owner_id" json:"owner_id"`
 	Title          string    `db:"title" json:"title"`
+	Description    string    `db:"description" json:"description"`
 	CreatedAt      string    `db:"created_at" json:"created_at"`
 	ModifiedAt     string    `db:"modified_at" json:"modified_at"`
 	IsPrivate      bool      `db:"is_private" json:"is_private"`
@@ -66,13 +67,14 @@ type CompletePanel struct {
 }
 
 type CompleteBoard struct {
-	Id         uuid.UUID       `db:"id" json:"id"`
-	OwnerId    string          `db:"owner_id" json:"owner_id"`
-	Title      string          `db:"title" json:"title"`
-	CreatedAt  string          `db:"created_at" json:"created_at"`
-	ModifiedAt string          `db:"modified_at" json:"modified_at"`
-	IsPrivate  bool            `db:"is_private" json:"is_private"`
-	Panels     []CompletePanel `json:"panels"`
+	Id          uuid.UUID       `db:"id" json:"id"`
+	OwnerId     string          `db:"owner_id" json:"owner_id"`
+	Title       string          `db:"title" json:"title"`
+	Description string          `db:"description" json:"description"`
+	CreatedAt   string          `db:"created_at" json:"created_at"`
+	ModifiedAt  string          `db:"modified_at" json:"modified_at"`
+	IsPrivate   bool            `db:"is_private" json:"is_private"`
+	Panels      []CompletePanel `json:"panels"`
 }
 
 type CompleteCard struct {
@@ -86,10 +88,26 @@ type CompleteCard struct {
 }
 
 type AIGeneratedCard struct {
-	AssignedUsers   []string    `json:"assigned"`
 	CardTitle       string      `json:"title"`
 	CardDesc        string      `json:"description"`
 	CardStoryPoints interface{} `json:"story_points"`
 }
 
 type AIGeneratedSprint map[string][]AIGeneratedCard
+
+type SimplifiedCompleteBoard struct {
+	Title       string                    `json:"title"`
+	Description string                    `json:"description"`
+	Panels      []SimplifiedCompletePanel `json:"panels"`
+}
+
+type SimplifiedCompletePanel struct {
+	Title  string                    `json:"title"`
+	Stacks []SimplifiedCompleteStack `json:"stacks"`
+}
+
+type SimplifiedCompleteStack struct {
+	Id    uuid.UUID         `db:"id" json:"id"`
+	Title string            `json:"title"`
+	Cards []AIGeneratedCard `json:"cards"`
+}

--- a/models/utility.go
+++ b/models/utility.go
@@ -39,3 +39,41 @@ func CopyToCompleteCard(source Card) CompleteCard {
 	dest.StackId = source.StackId
 	return dest
 }
+
+func CopyToSimplifiedCompleteBoard(source CompleteBoard) SimplifiedCompleteBoard {
+	dest := SimplifiedCompleteBoard{}
+	dest.Title = source.Title
+	dest.Description = source.Description
+	dest.Panels = make([]SimplifiedCompletePanel, len(source.Panels))
+	for i, panel := range source.Panels {
+		dest.Panels[i] = CopyToSimplifiedCompletePanel(panel)
+	}
+	return dest
+}
+
+func CopyToSimplifiedCompletePanel(source CompletePanel) SimplifiedCompletePanel {
+	dest := SimplifiedCompletePanel{}
+	dest.Title = source.Title
+	dest.Stacks = make([]SimplifiedCompleteStack, len(source.Stacks))
+	for i, stack := range source.Stacks {
+		dest.Stacks[i] = CopyToSimplifiedCompleteStack(stack)
+	}
+	return dest
+}
+
+func CopyToSimplifiedCompleteStack(source CompleteStack) SimplifiedCompleteStack {
+	dest := SimplifiedCompleteStack{}
+	dest.Cards = make([]AIGeneratedCard, len(source.Cards))
+	for i, card := range source.Cards {
+		dest.Cards[i] = CopyToAIGeneratedCard(card)
+	}
+	return dest
+}
+
+func CopyToAIGeneratedCard(source CompleteCard) AIGeneratedCard {
+	dest := AIGeneratedCard{}
+	dest.CardTitle = source.Title
+	dest.CardDesc = source.Description
+	dest.CardStoryPoints = source.Points
+	return dest
+}

--- a/routers/boardRouter.go
+++ b/routers/boardRouter.go
@@ -79,7 +79,7 @@ func registerBoardRoutes(parentRouter *mux.Router, cfg *config.Config, db *db.DB
 
 	handler.router.Handle(fmt.Sprintf("%s/{cardId}/assigned", cardsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.GetAllAssignedUsers))).Methods("GET")
 	handler.router.Handle(fmt.Sprintf("%s/{cardId}/assigned", cardsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.AssignCardToUser))).Methods("POST")
-	handler.router.Handle(fmt.Sprintf("%s/{cardId}/assigned", cardsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.UnassignCardFromUser))).Methods("DELETE")
+	handler.router.Handle(fmt.Sprintf("%s/{cardId}/assigned/{memberId}", cardsPrefix), auth.EnsureValidToken()(http.HandlerFunc(handler.UnassignCardFromUser))).Methods("DELETE")
 
 	return handler.router
 }
@@ -1283,8 +1283,7 @@ func (handler *boardHandler) UnassignCardFromUser(writer http.ResponseWriter, re
 	boardId := params["boardId"]
 	// stackId := params["stackId"]
 	cardId := params["cardId"]
-
-	memberId := request.FormValue("user_id")
+	memberId := params["memberId"]
 
 	token := request.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
 	tokenCustomClaims := token.CustomClaims.(*auth.CustomClaims)

--- a/routers/organizationRouter.go
+++ b/routers/organizationRouter.go
@@ -48,7 +48,7 @@ func (handler *organizationHandler) CreateOrganization(writer http.ResponseWrite
 		return
 	}
 	// addition of aiEnabledString variable allows for us to default to 'false' if '' is passed
-	aiEnabledString := request.FormValue("aiEnabled")
+	aiEnabledString := request.FormValue("ai_enabled")
 	if aiEnabledString == "" {
 		aiEnabledString = "false"
 	}

--- a/routers/organizationRouter.go
+++ b/routers/organizationRouter.go
@@ -113,11 +113,12 @@ func (handler *organizationHandler) UpdateOrganization(writer http.ResponseWrite
 	title := request.FormValue("title")
 	description := request.FormValue("description")
 	// addition of aiEnabledString variable allows for us to default to 'false' if '' is passed
-	aiEnabledString := request.FormValue("aiEnabled")
+	aiEnabledString := request.FormValue("ai_enabled")
 	if aiEnabledString == "" {
 		aiEnabledString = "false"
 	}
 	aiEnabled, err := strconv.ParseBool(aiEnabledString)
+	print(aiEnabled)
 	if err != nil {
 		http.Error(writer, fmt.Sprintf("Failed to parse aiEnabledString: %s", err.Error()), http.StatusBadRequest)
 		return

--- a/routers/organizationRouter.go
+++ b/routers/organizationRouter.go
@@ -118,7 +118,6 @@ func (handler *organizationHandler) UpdateOrganization(writer http.ResponseWrite
 		aiEnabledString = "false"
 	}
 	aiEnabled, err := strconv.ParseBool(aiEnabledString)
-	print(aiEnabled)
 	if err != nil {
 		http.Error(writer, fmt.Sprintf("Failed to parse aiEnabledString: %s", err.Error()), http.StatusBadRequest)
 		return

--- a/sql/SQL-Setup.sql
+++ b/sql/SQL-Setup.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS Organizations (
 CREATE TABLE IF NOT EXISTS Boards (
     id              UUID DEFAULT gen_random_uuid() PRIMARY KEY,
     title           VARCHAR(255) NOT NULL,
+    description     TEXT DEFAULT '',
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     modified_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     is_private      BOOLEAN DEFAULT FALSE,                  -- defaults to public


### PR DESCRIPTION
# Problem
See #72 for details
Closes #72
This PR is also related to [#8](https://github.com/Sync-Space-49/syncspace-ai/pull/8) in syncspace-ai

# Soltuion
The `CreateCardWithAI` controller method and it's respective route has been created to grab the board and send it to syncspace-ai to generate a card.

## Slight modifications
- Form data to all routes has been changed to be snake_case instead of camelCase (for consistency)
- `UnassignCardFromUser` route has been updated to be consistent with other remove/unassign routes
- The `board` table has been given a description column, as we use this in board generation, might as well keep it in the table
  - The alter table script is on dev db already
- `Assigned` has been removed from ai creation as it was unnecessary data
- `CreateBoardWithAI` has been updated to use `AIGeneratedSprint` as before this was not being used
- `CanUseAIForBoardCreation` was renamed to `CanUseAI` to not be confusing as why I'm using it in the card generation route

## Screenshots
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/dc872e7c-4bc3-47db-a041-59f41e4ad24d)
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/8f948bfc-4e7f-443e-a29f-19f8ae68a15d)
![image](https://github.com/Sync-Space-49/syncspace-server/assets/70990184/f3037ae8-8ae3-48e8-92d9-ddc631624f69)
