### PR TITLE
97 card return

### DIFF
--- a/controllers/user/user.go
+++ b/controllers/user/user.go
@@ -295,8 +295,8 @@ func (c *Controller) GetUserOwnedBoardsById(ctx context.Context, userId string) 
 	return &boards, nil
 }
 
-func (c *Controller) GetUserAssignedCardsById(ctx context.Context, userId string) (*[]models.Card, error) {
-	var cards []models.Card
+func (c *Controller) GetUserAssignedCardsById(ctx context.Context, userId string) (*[]models.DetailedAssignedCard, error) {
+	var cards []models.DetailedAssignedCard
 	err := c.db.DB.SelectContext(ctx, &cards, `
 	SELECT ac.user_id, c.*, s.id as stack_id, p.id as panel_id, b.id as board_id, o.id as org_id
 	FROM Assigned_Cards ac

--- a/controllers/user/user.go
+++ b/controllers/user/user.go
@@ -298,9 +298,14 @@ func (c *Controller) GetUserOwnedBoardsById(ctx context.Context, userId string) 
 func (c *Controller) GetUserAssignedCardsById(ctx context.Context, userId string) (*[]models.Card, error) {
 	var cards []models.Card
 	err := c.db.DB.SelectContext(ctx, &cards, `
-		SELECT c.* FROM Cards c
-		JOIN Assigned_Cards ac ON c.id = ac.card_id
-		WHERE ac.user_id = $1
+	SELECT ac.user_id, c.*, s.id as stack_id, p.id as panel_id, b.id as board_id, o.id as org_id
+	FROM Assigned_Cards ac
+	JOIN Cards c on ac.card_id = c.id
+	JOIN Stacks s ON c.stack_id = s.id
+	JOIN Panels p ON s.panel_id = p.id
+	JOIN Boards b ON p.board_id = b.id
+	JOIN organizations o ON b.organization_id = o.id
+	WHERE ac.user_id = $1;
 	`, userId)
 	if err != nil {
 		return nil, err

--- a/models/board.go
+++ b/models/board.go
@@ -111,3 +111,16 @@ type SimplifiedCompleteStack struct {
 	Title string            `json:"title"`
 	Cards []AIGeneratedCard `json:"cards"`
 }
+
+type DetailedAssignedCard struct {
+	UserID      string    `db:"user_id" json:"user_id"`
+	ID          uuid.UUID `db:"id" json:"id"`
+	Title       string    `db:"title" json:"title"`
+	Description string    `db:"description" json:"description"`
+	Position    int       `db:"position" json:"position"`
+	StackID     uuid.UUID `db:"stack_id" json:"stack_id"`
+	Points      string    `db:"points" json:"points"`
+	PanelID     uuid.UUID `db:"panel_id" json:"panel_id"`
+	BoardID     uuid.UUID `db:"board_id" json:"board_id"`
+	OrgID       uuid.UUID `db:"org_id" json:"org_id"`
+}


### PR DESCRIPTION
# Problem 
See #97 for details. 
TL:DR Assigned cards needed an associated board and org ID for routing reasons. 
Closes #97 

# Solution
Updated GetAssignedCards to return the ids of everything above it. 
![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/b1b57536-1437-4fa9-b56d-a9a2f50f1705)
