### PR TITLE
Change to allow the http:// or https:// declaration to be in the .env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ const (
 
 type Config struct {
 	Environment ENV    `default:"local" envconfig:"APP_ENV"`
-	APIHost     string `default:"127.0.0.1:8080" envconfig:"API_HOST"`
+	APIHost     string `default:"http://127.0.0.1:8080" envconfig:"API_HOST"`
 	JWTSecret   string `default:"bruh" envconfig:"JWT_SECRET"`
 	DB          struct {
 		DBUser string `default:"postgres" envconfig:"DB_USER"`
@@ -50,7 +50,7 @@ type Config struct {
 		}
 	}
 	AI struct {
-		APIHost string `default:"127.0.0.1:3999" envconfig:"AI_API_HOST"`
+		APIHost string `default:"http://127.0.0.1:3999" envconfig:"AI_API_HOST"`
 	}
 }
 

--- a/controllers/board/board.go
+++ b/controllers/board/board.go
@@ -355,7 +355,7 @@ func (c *Controller) RemoveMemberFromBoard(ctx context.Context, userId string, o
 }
 
 func (c *Controller) CreateBoardWithAI(ctx context.Context, userId string, name string, description string, isPrivate bool, orgId string, detailLevel string, storyPointType string, storyPointExamples string) (*models.Board, error) {
-	requestUrl := fmt.Sprintf("http://%s/api/generate/board", c.cfg.AI.APIHost)
+	requestUrl := fmt.Sprintf("%s/api/generate/board", c.cfg.AI.APIHost)
 	formData := url.Values{}
 	formData.Add("title", name)
 	formData.Add("description", description)

--- a/controllers/board/card.go
+++ b/controllers/board/card.go
@@ -177,7 +177,7 @@ func (c *Controller) DeleteCardById(ctx context.Context, boardId string, stackId
 }
 
 func (c *Controller) CreateCardWithAI(ctx context.Context, boardId string, cardStackId string) (*models.Card, error) {
-	requestUrl := fmt.Sprintf("http://%s/api/generate/card", c.cfg.AI.APIHost)
+	requestUrl := fmt.Sprintf("%s/api/generate/card", c.cfg.AI.APIHost)
 
 	detailedBoard, err := c.GetCompleteBoardById(ctx, boardId)
 	if err != nil {


### PR DESCRIPTION
small PR moving the http hard-coded into some routes for AI into the ENV so that we can use the HTTPS hosting on google cloud


closes #99 

screenshot of functional AI code after this change using a hosted AI server:

![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/ee48f4cf-cabc-4c53-92ce-f0b5b24a7e78)
![image](https://github.com/Sync-Space-49/syncspace-server/assets/26585103/2220c0a3-0af2-422e-831d-de62a65cf2bb)
